### PR TITLE
Resume the audio context if it is not in running state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-play-audio",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "A node-red node for playing audio in the browser",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -10,21 +10,25 @@
     "url": "https://github.com/lorentzlasson/node-red-contrib-play-audio.git"
   },
   "keywords": [
-    "node-red", "audio", "TTS", "text-to-speech"
+    "node-red",
+    "audio",
+    "TTS",
+    "text-to-speech"
   ],
   "author": "Lorentz Lasson",
-  "contributors": [ {
+  "contributors": [
+    {
       "name": "Dave Conway-Jones"
-      }
+    }
   ],
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/lorentzlasson/node-red-contrib-play-audio/issues"
   },
   "homepage": "https://github.com/lorentzlasson/node-red-contrib-play-audio",
-  "node-red"     : {
-        "nodes": {
-            "play-audio": "play-audio.js"
-        }
+  "node-red": {
+    "nodes": {
+      "play-audio": "play-audio.js"
     }
+  }
 }

--- a/play-audio.html
+++ b/play-audio.html
@@ -45,12 +45,12 @@
 
                 ( function () {
                     return new Promise(function resolver(resolve, reject) {
-                        if ('running' === context.state) {
-                            resolve();
-                        } else {
+                        if (context.state && 'running' !== context.state && context.resume) {
                             context.resume().then(() => {
                                 resolve();
                             })
+                        } else {
+                          resolve();
                         }
                     });
                 }()).then(() => {

--- a/play-audio.html
+++ b/play-audio.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <!--
   Copyright 2015 Lorentz Lasson
-  Copyright 2015, 2016 Lorentz Lasson, Dave Conway-Jones
+  Copyright 2015, 2016, 2018 Lorentz Lasson, Dave Conway-Jones
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -42,28 +42,45 @@
 
             this.handleAudio = function(t,o) {
                 var byteArray = (o.hasOwnProperty("data")) ? o.data : o;
-                try {
-                    var source = context.createBufferSource();
-                    var buffer = new Uint8Array(byteArray.length);
-                    buffer.set(new Uint8Array(byteArray), 0);
-                    context.decodeAudioData(buffer.buffer, function(buffer) {
-                        source.buffer = buffer;
-                        source.onended = function() {
-                            $.getJSON('playaudio',function() { });
-                            sources = sources.filter(function(s) {
-                                if (source === s) { return false; }
-                                else { return true; }
-                            });
 
+                ( function () {
+                    return new Promise(function resolver(resolve, reject) {
+                        if ('running' === context.state) {
+                            resolve();
+                        } else {
+                            context.resume().then(() => {
+                                resolve();
+                            })
                         }
-                        source.connect(context.destination);
-                        source.start(0);
-                        sources.push(source);
                     });
-                }
-                catch(e) {
-                    alert("Error playing audio: "+e);
-                }
+                }()).then(() => {
+                  try {
+                      var source = context.createBufferSource();
+                      var buffer = new Uint8Array(byteArray.length);
+                      buffer.set(new Uint8Array(byteArray), 0);
+                      context.decodeAudioData(buffer.buffer, function(buffer) {
+                          source.buffer = buffer;
+                          source.onended = function() {
+                              $.getJSON('playaudio',function() { });
+                              sources = sources.filter(function(s) {
+                                  if (source === s) { return false; }
+                                  else { return true; }
+                              });
+
+                          }
+                          source.connect(context.destination);
+                          source.start(0);
+                          sources.push(source);
+                      });
+                  }
+                  catch(e) {
+                      alert("Error playing audio: "+e);
+                  }
+                }).catch((e)=> {
+                    alert("Audio context error: "+e);
+                });
+
+
             };
 
             this.handleTTS = function(t,o) {


### PR DESCRIPTION
On Chrome if the audio context is created on page load then it now defaults to a paused state, and will fail to play the audio - https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#webaudio

As the resume method returns a promise, I have embedded and invoked an anonymous function that tests the audio context state, then resumes it if it is not already in running state. 

The createBufferSource function waits until the running promise is resolved. 

I have tested on chrome and safari.