### PR TITLE
Support i18n in info tab

### DIFF
--- a/locales/en-US/play-audio.html
+++ b/locales/en-US/play-audio.html
@@ -1,0 +1,8 @@
+<script type="text/x-red" data-help-name="play audio">
+    <p>A node to play audio in the browser.</p>
+    <p>To work the editor web page must be open.</p>
+    <p>Expects <code>msg.payload</code> to contain a buffer of a <b>wav</b> file.</p>
+    <p>If your browser has native support for Text-to-Speech then a <code>msg.payload</code>
+    can also be a <b>string</b> to be read aloud.</p>
+    <p>The button will stop the audio that is currently playing.</p>
+</script>

--- a/locales/ja/play-audio.html
+++ b/locales/ja/play-audio.html
@@ -1,0 +1,7 @@
+<script type="text/x-red" data-help-name="play audio">
+    <p>プラウザ上で音声を再生するノード。</p>
+    <p>動作させるには、エディタのウェブページを開いておく必要があります。</p>
+    <p><code>msg.payload</code>に<b>wav</b>ファイルのバッファが含まれることが期待されます。</p>
+    <p>もしブラウザがText-to-Speechをネイティブサポートしている場合は、<code>msg.payload</code>は読み上げる<b>文字列</b>にすることもできます。</p>
+    <p>ボタンは現在再生している音声を停止させます。</p>
+</script>

--- a/play-audio.html
+++ b/play-audio.html
@@ -142,12 +142,3 @@
         <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
 </script>
-
-<script type="text/x-red" data-help-name="play audio">
-    <p>A node to play audio in the browser.</p>
-    <p>To work the editor web page must be open.</p>
-    <p>Expects <code>msg.payload</code> to contain a buffer of a <b>wav</b> file.</p>
-    <p>If your browser has native support for Text-to-Speech then a <code>msg.payload</code>
-    can also be a <b>string</b> to be read aloud.</p>
-    <p>The button will stop the audio that is currently playing.</p>
-</script>


### PR DESCRIPTION
I added Japanese translations for the info tab. Simultaneously, I moved English messages to `locales/en-US` directory.